### PR TITLE
MPI: OpenMPI 5.0 / C++-binding-removal compatibility

### DIFF
--- a/include/andi.hxx
+++ b/include/andi.hxx
@@ -7,7 +7,7 @@
 // Define
 //--------
 #ifdef USE_MPI
-#define EXIT {MPI::COMM_WORLD.Barrier(); MPI::COMM_WORLD.Abort(0);}
+#define EXIT {MPI_Barrier(MPI_COMM_WORLD); MPI_Abort(MPI_COMM_WORLD, 0);}
 #else
 #define EXIT exit(0)
 #endif

--- a/include/vmec_class.hxx
+++ b/include/vmec_class.hxx
@@ -871,7 +871,7 @@ return(*this);
 void VMEC::read(LA_STRING filename)
 {
 #ifdef USE_MPI
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 #else
 int mpi_rank = 0;
 #endif

--- a/include/xpand_class.hxx
+++ b/include/xpand_class.hxx
@@ -10,11 +10,9 @@
 // Include
 //--------
 #ifdef USE_MPI
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #endif
 #include <la_string.hxx>
 #include <fstream>
@@ -652,7 +650,7 @@ return(*this);
 void BFIELDVC::init(VMEC woutin, LA_STRING mgrid_file)
 {
 #ifdef USE_MPI
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 #else
 int mpi_rank = 0;
 #endif
@@ -933,8 +931,8 @@ for(j=1;j<=Nv;j++) V(j) = (j-1)*dv;
 
 #ifdef USE_MPI
 // Prepare parallel execution
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 int mpi_parts = Nu*Nv / mpi_size;
 int kstart = 1 + mpi_rank*mpi_parts;
 int kend = (mpi_rank + 1)*mpi_parts;
@@ -1001,29 +999,29 @@ for(k=kstart;k<=kend;k++)
 // send results to every node
 double *buffer;
 buffer = Rs.dataZero() + Rs.stride(firstDim)*istart + Rs.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, Rs.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, Rs.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = Zs.dataZero() + Zs.stride(firstDim)*istart + Zs.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, Zs.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, Zs.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = KR.dataZero() + KR.stride(firstDim)*istart + KR.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, KR.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, KR.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = Kp.dataZero() + Kp.stride(firstDim)*istart + Kp.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, Kp.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, Kp.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = KZ.dataZero() + KZ.stride(firstDim)*istart + KZ.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, KZ.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, KZ.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = nB.dataZero() + nB.stride(firstDim)*istart + nB.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, nB.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, nB.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = dRdu.dataZero() + dRdu.stride(firstDim)*istart + dRdu.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, dRdu.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, dRdu.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = dRdv.dataZero() + dRdv.stride(firstDim)*istart + dRdv.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, dRdv.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, dRdv.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = d2R.dataZero() + d2R.stride(firstDim)*istart + d2R.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, d2R.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, d2R.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = dZdu.dataZero() + dZdu.stride(firstDim)*istart + dZdu.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, dZdu.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, dZdu.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = dZdv.dataZero() + dZdv.stride(firstDim)*istart + dZdv.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, dZdv.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, dZdv.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 buffer = d2Z.dataZero() + d2Z.stride(firstDim)*istart + d2Z.stride(secondDim)*jstart;
-MPI::COMM_WORLD.Allgather(buffer, mpi_parts, MPI::DOUBLE, d2Z.dataFirst(), mpi_parts, MPI::DOUBLE);
+MPI_Allgather(buffer, mpi_parts, MPI_DOUBLE, d2Z.dataFirst(), mpi_parts, MPI_DOUBLE, MPI_COMM_WORLD);
 
 int origin;
 if((mpi_size*mpi_parts) < (Nu*Nv))
@@ -1035,29 +1033,29 @@ if((mpi_size*mpi_parts) < (Nu*Nv))
 	origin = mpi_size-1;
 
 	buffer = Rs.dataZero() + Rs.stride(firstDim)*istart + Rs.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = Zs.dataZero() + Zs.stride(firstDim)*istart + Zs.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = KR.dataZero() + KR.stride(firstDim)*istart + KR.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = Kp.dataZero() + Kp.stride(firstDim)*istart + Kp.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = KZ.dataZero() + KZ.stride(firstDim)*istart + KZ.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = nB.dataZero() + nB.stride(firstDim)*istart + nB.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = dRdu.dataZero() + dRdu.stride(firstDim)*istart + dRdu.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = dRdv.dataZero() + dRdv.stride(firstDim)*istart + dRdv.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = d2R.dataZero() + d2R.stride(firstDim)*istart + d2R.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = dZdu.dataZero() + dZdu.stride(firstDim)*istart + dZdu.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = dZdv.dataZero() + dZdv.stride(firstDim)*istart + dZdv.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 	buffer = d2Z.dataZero() + d2Z.stride(firstDim)*istart + d2Z.stride(secondDim)*jstart;
-	MPI::COMM_WORLD.Bcast(buffer, mpi_parts, MPI::DOUBLE, origin);
+	MPI_Bcast(buffer, mpi_parts, MPI_DOUBLE, origin, MPI_COMM_WORLD);
 }
 #endif
 
@@ -1215,7 +1213,7 @@ b *= 1e-7*I;	// mu0/4pi * I
 int read_extcur(Array<double,1>& extcur, LA_STRING input_extension)
 {
 #ifdef USE_MPI
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 #else
 int mpi_rank = 0;
 #endif

--- a/install/make.inc.HEAT
+++ b/install/make.inc.HEAT
@@ -30,7 +30,7 @@ DEFS = -Dm3dc1_newfio
 # ---- external Libraries ----
 BLITZLIBS = -L/root/source/MAFOT/blitz++/blitz-0.9/lib -lblitz
 FLIBS = -L/usr/lib/x86_64-linux-gnu -lgfortran
-OMPLIBS = -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi
 M3DC1LIBS = -L/root/source/M3DC1/build/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi -lhdf5_cpp -lhdf5
 NETCDFLIBS = -L/usr/lib/x86_64-linux-gnu -lnetcdf

--- a/install/make.inc.Tom
+++ b/install/make.inc.Tom
@@ -34,7 +34,7 @@ DEFS = -Dm3dc1_newfio
 # ---- external Libraries ----
 BLITZLIBS = -L/home/tom/source/MAFOT/blitz++/blitz-0.9/lib -lblitz
 FLIBS = -L/usr/lib/x86_64-linux-gnu -lgfortran
-OMPLIBS = -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/lib/x86_64-linux-gnu/openmpi/lib -lmpi
 M3DC1LIBS = -L/opt/m3dc1/build/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/lib/x86_64-linux-gnu/hdf5/serial
 NETCDFLIBS = -L/usr/lib/x86_64-linux-gnu -lnetcdf

--- a/install/make.inc.bb8
+++ b/install/make.inc.bb8
@@ -29,7 +29,7 @@ DEFS = -Dm3dc1_newfio
 # ---- external Libraries ---- 
 BLITZLIBS = -L/home/shared/mafot/lib -lblitz
 FLIBS = -L/usr/lib64 -lgfortran -lpthread
-OMPLIBS = -L/usr/lib64/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/lib64/openmpi/lib -lmpi
 M3DC1LIBS = -L/home/shared/m3dc1/fusion-io/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/lib64 -lz -Wl,-rpath,/usr/lib64 -lstdc++
 NETCDFLIBS = -L/usr/lib64/openmpi/lib -lnetcdf -lhdf5

--- a/install/make.inc.drop
+++ b/install/make.inc.drop
@@ -26,7 +26,7 @@ LDFLAGS =
 # ---- external Libraries ---- 
 BLITZLIBS = -L/home/wingen/lib/64/blitz/lib -lblitz
 FLIBS = -L/opt/intel/composerxe-2011.0.084/lib/intel64 -lsvml -lifcore -lirc -ldl -limf
-OMPLIBS = -L/act/openmpi-1.6/gcc/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/act/openmpi-1.6/gcc/lib -lmpi
 M3DC1LIBS = -L/home/ferraro/lib/_drop -lfusionio -lm3dc1
 HDF5LIBS = -L/home/wingen/lib/64/hdf5/lib -lhdf5 -lz -Wl,-rpath,/home/wingen/lib/64/hdf5/lib -lstdc++
 NETCDFLIBS = -L/opt/netcdf-4.1.3-intel/lib -lnetcdf

--- a/install/make.inc.fusion2
+++ b/install/make.inc.fusion2
@@ -26,7 +26,7 @@ LDFLAGS =
 # ---- external Libraries ---- 
 BLITZLIBS = -L/home/wwj/lib64/blitz/lib -lblitz
 FLIBS = -L/usr/lib/gcc/x86_64-linux-gnu/5 -lgfortran -L/usr/lib/x86_64-linux-gnu -lpthread
-OMPLIBS = -L/usr/lib/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/lib/openmpi/lib -lmpi
 M3DC1LIBS = -L/home/jjl/m3dc1/install/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi -lhdf5 -lz -Wl,-rpath,/usr/lib/x86_64-linux-gnu -lstdc++
 NETCDFLIBS = -L/usr/lib/x86_64-linux-gnu -lnetcdf

--- a/install/make.inc.pegasus
+++ b/install/make.inc.pegasus
@@ -26,7 +26,7 @@ LDFLAGS =
 # ---- external Libraries ---- 
 BLITZLIBS = -L/Users/wingen/Documents/Eclipse/Lib/blitz/lib -lblitz
 FLIBS = -L/usr/local/gfortran/lib -lgfortran
-OMPLIBS = -L/usr/local/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/local/openmpi/lib -lmpi
 M3DC1LIBS = 
 HDF5LIBS = 
 NETCDFLIBS = -L/opt/local/lib -lnetcdf

--- a/install/make.inc.portal
+++ b/install/make.inc.portal
@@ -29,7 +29,7 @@ DEFS = -Dm3dc1_newfio
 # ---- external Libraries ----
 BLITZLIBS = -L/p/mafot/lib -lblitz
 FLIBS = -L/usr/pppl/gcc/11.2.0/lib64 -lgfortran
-OMPLIBS = -L/usr/pppl/gcc/11.2-pkgs/openmpi-4.1.2/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/pppl/gcc/11.2-pkgs/openmpi-4.1.2/lib -lmpi
 M3DC1LIBS = -L/p/tsc/fio/fio-pppl_gcc/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/pppl/gcc/11.2-pkgs/openmpi-4.1.2-pkgs/hdf5-parallel-1.12.1/lib -lhdf5 -Wl,-rpath,/usr/pppl/gcc/11.2.0/lib64 -lstdc++
 NETCDFLIBS = -L/usr/pppl/gcc/11.2-pkgs/netcdf-c-4.8.1/lib -lnetcdf

--- a/install/make.inc.r2d2
+++ b/install/make.inc.r2d2
@@ -26,7 +26,7 @@ LDFLAGS =
 # ---- external Libraries ---- 
 BLITZLIBS = -L/home/wingen/lib/64/blitz/lib -lblitz
 FLIBS = -L/usr/lib -lgfortran -L/lib64 -lpthread
-OMPLIBS = -L/usr/local/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/usr/local/openmpi/lib -lmpi
 M3DC1LIBS = -L/usr/local/m3dc1/lib -lfusionio -lm3dc1
 HDF5LIBS = -L/usr/local/hdf5/lib -lhdf5 -lz -Wl,-rpath,/usr/local/hdf5/lib -lstdc++
 NETCDFLIBS = -L/usr/lib64 -lnetcdf

--- a/install/make.inc.star
+++ b/install/make.inc.star
@@ -24,7 +24,7 @@ LDFLAGS = -m32
 # ---- external Libraries ---- 
 BLITZLIBS = -L/home/wingen/lib/32/blitz/lib -lblitz
 FLIBS = -L/usr/lib -lgfortran
-OMPLIBS = -L/home/wingen/lib/32/openmpi/lib -lmpi -lmpi_cxx
+OMPLIBS = -L/home/wingen/lib/32/openmpi/lib -lmpi
 M3DC1LIBS = 
 HDF5LIBS = 
 

--- a/src/foot_mpi.cxx
+++ b/src/foot_mpi.cxx
@@ -34,11 +34,9 @@
 
 // Include
 //--------
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #include <mafot.hxx>
 #include <omp.h>
 #include <unistd.h>
@@ -57,9 +55,9 @@
 int main(int argc, char *argv[])
 {
 // MPI initialize
-MPI::Init(argc, argv);
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+MPI_Init(&argc, &argv);
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
 // Variables
 int i,j;
@@ -72,7 +70,7 @@ vector<string> coeffs;
 int tag,sender;
 double tmin_slave,tmax_slave,dt;
 Array<double,1> send_t_limits(Range(1,2));
-MPI::Status status;
+MPI_Status status;
 
 // Use system time as seed(=idum) for random numbers
 double now = zeit();
@@ -138,7 +136,7 @@ case 'h':
 		cout << "                       use option -I to specify other filename" << endl;
 		cout << endl << "Current MAFOT version is: " << MAFOT_VERSION << endl;
 	}
-	MPI::Finalize();
+	MPI_Finalize();
 	return 0;
 case 'I':
 	islandfile = optarg;
@@ -361,7 +359,7 @@ if (use_collision) COL.init(TprofileFile, NprofileFile, f, zbar, PAR.Zq, PAR.Mas
 // Prepare particles
 PARTICLE FLT(EQD,PAR,COL,mpi_rank);
 
-MPI::COMM_WORLD.Barrier();	// Syncronize all Nodes
+MPI_Barrier(MPI_COMM_WORLD);	// Syncronize all Nodes
 
 // Master only (Node 0)
 //--------------------------------------------------------------------------------------------------
@@ -428,7 +426,7 @@ if(mpi_rank < 1)
 		#pragma omp section	//-------- Master Thread: controlles comunication ----------------------------------------------------------------------------------------------------------------------
 		{
 			//#pragma omp barrier	// Syncronize with Slave Thread
-			MPI::COMM_WORLD.Barrier();	// Master waits for Slaves
+			MPI_Barrier(MPI_COMM_WORLD);	// Master waits for Slaves
 
 			//ofs2 << "Target (0=vertical, 1=45�, 2=horizontal, 3=shelf): " << which_target_plate << endl;
 			ofs3 << "Start Tracer for " << N << " points ... " << endl;
@@ -447,14 +445,14 @@ if(mpi_rank < 1)
 					send_t_limits(1) = t_values((tag-1)*Nt_slave+1);	// tmin_slave
 					send_t_limits(2) = t_values(tag*Nt_slave);	// tmax_slave
 
-					MPI::COMM_WORLD.Send(send_t_limits.dataFirst(),2,MPI::DOUBLE,i,tag);
+					MPI_Send(send_t_limits.dataFirst(),2,MPI_DOUBLE,i,tag, MPI_COMM_WORLD);
 					workingNodes += 1;
 
 					ofs3 << "Send Package No.: " << tag << endl;
 				}
 				else	// more Nodes than Packages -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_t_limits.dataFirst(),0,MPI::DOUBLE,i,0);
+					MPI_Send(send_t_limits.dataFirst(),0,MPI_DOUBLE,i,0, MPI_COMM_WORLD);
 					ofs3 << "Send termination signal to Node: " << i << endl;
 				}
 			} // end for(i=1;i<mpi_size;i++)
@@ -463,9 +461,9 @@ if(mpi_rank < 1)
 			while(workingNodes > 0)	// workingNodes > 0: Slave still working -> MPI:Revc needed		workingNodes == 0: all Slaves recieved termination signal
 			{
 				// Recieve Result
-				MPI::COMM_WORLD.Recv(recieve.dataFirst(),N_variables*N_slave,MPI::DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG,status);
-				sender = status.Get_source();
-				tag = status.Get_tag();
+				MPI_Recv(recieve.dataFirst(),N_variables*N_slave,MPI_DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+				sender = status.MPI_SOURCE;
+				tag = status.MPI_TAG;
 				ofs3 << "Recieve from Node: " << sender << " Package: " << tag << endl;
 
 				#pragma omp critical
@@ -490,12 +488,12 @@ if(mpi_rank < 1)
 					send_t_limits(1) = t_values((tag-1)*Nt_slave+1);	// tmin_slave
 					send_t_limits(2) = t_values(tag*Nt_slave);	// tmax_slave
 
-					MPI::COMM_WORLD.Send(send_t_limits.dataFirst(),2,MPI::DOUBLE,sender,tag);
+					MPI_Send(send_t_limits.dataFirst(),2,MPI_DOUBLE,sender,tag, MPI_COMM_WORLD);
 					ofs3 << "Send again to Node: " << sender << " Package No.: " << tag << endl;
 				}
 				else	// No Packages left -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_t_limits.dataFirst(),0,MPI::DOUBLE,sender,0);
+					MPI_Send(send_t_limits.dataFirst(),0,MPI_DOUBLE,sender,0, MPI_COMM_WORLD);
 					workingNodes -= 1;
 					ofs3 << "Send termination signal to Node: " << sender << endl;
 				}
@@ -606,7 +604,7 @@ if(mpi_rank > 0)
 	prepare_common_perturbations(EQD,PAR,mpi_rank,siestafile,xpandfile,islandfile);
 	prep_perturbation(EQD,PAR,mpi_rank);
 
-	MPI::COMM_WORLD.Barrier();	// Syncronize with Master
+	MPI_Barrier(MPI_COMM_WORLD);	// Syncronize with Master
 
 	ofs2 << "Target: " << PAR.which_target_plate << endl;
 
@@ -617,9 +615,9 @@ if(mpi_rank > 0)
 	while(1)	
 	{
 		// Recieve initial conditions to calculate
-		MPI::COMM_WORLD.Recv(send_t_limits.dataFirst(),2,MPI::DOUBLE,0,MPI_ANY_TAG,status);
+		MPI_Recv(send_t_limits.dataFirst(),2,MPI_DOUBLE,0,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-		tag = status.Get_tag();
+		tag = status.MPI_TAG;
 		ofs2 << endl;
 		ofs2 << "Node: " << mpi_rank << " works on Package: " << tag << endl;
 		if(tag == 0) break;	// Still work to do?  ->  tag = 0: NO, stop working
@@ -650,7 +648,7 @@ if(mpi_rank > 0)
 		}
 
 		// Send results to Master
-		MPI::COMM_WORLD.Send(results.dataFirst(),N_variables*N_slave,MPI::DOUBLE,0,tag);
+		MPI_Send(results.dataFirst(),N_variables*N_slave,MPI_DOUBLE,0,tag, MPI_COMM_WORLD);
 
 	}// end while
 } // end Slaves
@@ -669,7 +667,7 @@ if(PAR.response_field >= 0) M3D.unload();
 #endif
 
 // MPI finalize
-MPI::Finalize();
+MPI_Finalize();
 
 return 0; 
 } //end of main

--- a/src/laminar_mpi.cxx
+++ b/src/laminar_mpi.cxx
@@ -34,11 +34,10 @@
 
 // Include
 //--------
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+// MPI header: C API (portable across OpenMPI 4.x/5.x and MPICH)
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #include <mafot.hxx>
 #include <omp.h>
 #include <unistd.h>
@@ -58,9 +57,9 @@ int pitch_angles(double R, double Z, double phi, double& pitch, double& yaw, EFI
 int main(int argc, char *argv[])
 {
 // MPI initialize
-MPI::Init(argc, argv);
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+MPI_Init(&argc, &argv);
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
 // Variables
 EFIT EQD;
@@ -75,7 +74,7 @@ Range all = Range::all();
 int tag,sender;
 double Zmin_slave,Zmax_slave,dz;
 Array<double,1> send_Z_limits(Range(1,2));
-MPI::Status status;
+MPI_Status status;
 
 // Use system time as seed(=idum) for random numbers
 double now = zeit();
@@ -162,7 +161,7 @@ case 'h':
 		cout << "                       use option -I to specify other filename" << endl;
 		cout << endl << "Current MAFOT version is: " << MAFOT_VERSION << endl;
 	}
-	MPI::Finalize();
+	MPI_Finalize();
 	return 0;
 case 'b':
 	simpleBndy = 1;
@@ -389,7 +388,7 @@ if (use_collision) COL.init(TprofileFile, NprofileFile, f, zbar, PAR.Zq, PAR.Mas
 // Prepare particles
 PARTICLE FLT(EQD,PAR,COL,mpi_rank);
 
-MPI::COMM_WORLD.Barrier();	// Syncronize all Nodes
+MPI_Barrier(MPI_COMM_WORLD);	// Syncronize all Nodes
 
 // Master only (Node 0)
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -468,7 +467,7 @@ if(mpi_rank < 1)
 		#pragma omp section	//-------- Master Thread: controlles comunication ----------------------------------------------------------------------------------------------------------------------
 		{
 			//#pragma omp barrier	// Syncronize with Slave Thread
-			MPI::COMM_WORLD.Barrier();	// Master waits for Slaves
+			MPI_Barrier(MPI_COMM_WORLD);	// Master waits for Slaves
 
 			//ofs3 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << MapDirection << endl;
 			ofs3 << "Start Tracer for " << N << " points ... " << endl;
@@ -487,14 +486,14 @@ if(mpi_rank < 1)
 					send_Z_limits(1) = Z_values((tag-1)*NZ_slave+1);	// Zmin_slave
 					send_Z_limits(2) = Z_values(tag*NZ_slave);	// Zmax_slave
 
-					MPI::COMM_WORLD.Send(send_Z_limits.dataFirst(),2,MPI::DOUBLE,i,tag);
+					MPI_Send(send_Z_limits.dataFirst(),2,MPI_DOUBLE,i,tag, MPI_COMM_WORLD);
 					workingNodes += 1;
 
 					ofs3 << "Send Package No.: " << tag << endl;
 				}
 				else	// more Nodes than Packages -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_Z_limits.dataFirst(),0,MPI::DOUBLE,i,0);
+					MPI_Send(send_Z_limits.dataFirst(),0,MPI_DOUBLE,i,0, MPI_COMM_WORLD);
 					ofs3 << "Send termination signal to Node: " << i << endl;
 				}
 			} // end for(i=1;i<mpi_size;i++)
@@ -503,9 +502,9 @@ if(mpi_rank < 1)
 			while(workingNodes > 0)	// workingNodes > 0: Slave still working -> MPI:Revc needed		workingNodes == 0: all Slaves recieved termination signal
 			{
 				// Recieve Result
-				MPI::COMM_WORLD.Recv(recieve.dataFirst(),N_variables*N_slave,MPI::DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG,status);
-				sender = status.Get_source();
-				tag = status.Get_tag();
+				MPI_Recv(recieve.dataFirst(),N_variables*N_slave,MPI_DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+				sender = status.MPI_SOURCE;
+				tag = status.MPI_TAG;
 				ofs3 << "Recieve from Node: " << sender << " Package: " << tag << endl;
 
 				#pragma omp critical
@@ -530,12 +529,12 @@ if(mpi_rank < 1)
 					send_Z_limits(1) = Z_values((tag-1)*NZ_slave+1);	// Zmin_slave
 					send_Z_limits(2) = Z_values(tag*NZ_slave);	// Zmax_slave
 
-					MPI::COMM_WORLD.Send(send_Z_limits.dataFirst(),2,MPI::DOUBLE,sender,tag);
+					MPI_Send(send_Z_limits.dataFirst(),2,MPI_DOUBLE,sender,tag, MPI_COMM_WORLD);
 					ofs3 << "Send again to Node: " << sender << " Package No.: " << tag << endl;
 				}
 				else	// No Packages left -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_Z_limits.dataFirst(),0,MPI::DOUBLE,sender,0);
+					MPI_Send(send_Z_limits.dataFirst(),0,MPI_DOUBLE,sender,0, MPI_COMM_WORLD);
 					workingNodes -= 1;
 					ofs3 << "Send termination signal to Node: " << sender << endl;
 				}
@@ -762,7 +761,7 @@ if(mpi_rank > 0)
 	prepare_common_perturbations(EQD,PAR,mpi_rank,siestafile,xpandfile,islandfile);
 	prep_perturbation(EQD,PAR,mpi_rank);
 
-	MPI::COMM_WORLD.Barrier();	// Syncronize with Master
+	MPI_Barrier(MPI_COMM_WORLD);	// Syncronize with Master
 
 	ofs2 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << PAR.MapDirection << endl;
 
@@ -773,9 +772,9 @@ if(mpi_rank > 0)
 	while(1)	
 	{
 		// Recieve initial conditions to calculate
-		MPI::COMM_WORLD.Recv(send_Z_limits.dataFirst(),2,MPI::DOUBLE,0,MPI_ANY_TAG,status);
+		MPI_Recv(send_Z_limits.dataFirst(),2,MPI_DOUBLE,0,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-		tag = status.Get_tag();
+		tag = status.MPI_TAG;
 		ofs2 << endl;
 		ofs2 << "Node: " << mpi_rank << " works on Package: " << tag << endl;
 		if(tag == 0) break;	// Still work to do?  ->  tag = 0: NO, stop working
@@ -919,7 +918,7 @@ if(mpi_rank > 0)
 		} // end for
 
 		// Send results to Master
-		MPI::COMM_WORLD.Send(results.dataFirst(),N_variables*N_slave,MPI::DOUBLE,0,tag);
+		MPI_Send(results.dataFirst(),N_variables*N_slave,MPI_DOUBLE,0,tag, MPI_COMM_WORLD);
 
 	}// end while
 } // end Slaves
@@ -938,7 +937,7 @@ if(PAR.response_field >= 0) M3D.unload();
 #endif
 
 // MPI finalize
-MPI::Finalize();
+MPI_Finalize();
 
 return 0; 
 } //end of main

--- a/src/plot_mpi.cxx
+++ b/src/plot_mpi.cxx
@@ -32,11 +32,9 @@
 
 // Include
 //--------
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #include <mafot.hxx>
 #include <omp.h>
 #include <unistd.h>
@@ -56,9 +54,9 @@ using namespace blitz;
 int main(int argc, char *argv[])
 {
 // MPI initialize
-MPI::Init(argc, argv);
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+MPI_Init(&argc, &argv);
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
 // Variables
 int i,j,n,chk;
@@ -69,7 +67,7 @@ double s,u;
 int tag,sender;
 int Nmin_slave,Nmax_slave;
 Array<int,1> send_N_limits(Range(1,2));
-MPI::Status status;
+MPI_Status status;
 
 // Use system time as seed(=idum) for random numbers
 double now=zeit();
@@ -131,7 +129,7 @@ case 'h':
 		cout << "                       use option -I to specify other filename" << endl;
 		cout << endl << "Current MAFOT version is: " << MAFOT_VERSION << endl;
 	}
-	MPI::Finalize();
+	MPI_Finalize();
 	return 0;
 case 'I':
 	islandfile = optarg;
@@ -196,7 +194,7 @@ ofstream ofs3;
 // Output
 LA_STRING filenameout = "plot" + praefix + ".dat";
 if(mpi_rank < 1) outputtest(filenameout);
-MPI::COMM_WORLD.Barrier();	// All Nodes wait for Master
+MPI_Barrier(MPI_COMM_WORLD);	// All Nodes wait for Master
 
 // Read parameter file
 if(mpi_rank < 1) cout << "Read Parameterfile " << parfilename << endl;
@@ -264,7 +262,7 @@ if (use_collision) COL.init(TprofileFile, NprofileFile, f, zbar, PAR.Zq, PAR.Mas
 // Prepare particles
 PARTICLE FLT(EQD,PAR,COL,mpi_rank);
 
-MPI::COMM_WORLD.Barrier();	// Syncronize all Nodes
+MPI_Barrier(MPI_COMM_WORLD);	// Syncronize all Nodes
 
 // Master only (Node 0)
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -349,7 +347,7 @@ if(mpi_rank < 1)
 		#pragma omp section	//-------- Master Thread: controlles comunication ----------------------------------------------------------------------------------------------------------------------
 		{
 			//#pragma omp barrier	// Syncronize with Slave Thread
-			MPI::COMM_WORLD.Barrier();	// Master waits for Slaves
+			MPI_Barrier(MPI_COMM_WORLD);	// Master waits for Slaves
 
 			ofs3 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << PAR.MapDirection << endl;
 			ofs3 << "Start Tracer for " << N << " points ... " << endl;
@@ -368,14 +366,14 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,i,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,i,tag, MPI_COMM_WORLD);
 					workingNodes += 1;
 
 					ofs3 << "Send Package No.: " << tag << endl;
 				}
 				else	// more Nodes than Packages -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,i,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,i,0, MPI_COMM_WORLD);
 					ofs3 << "Send termination signal to Node: " << i << endl;
 				}
 			} // end for(i=1;i<mpi_size;i++)
@@ -384,9 +382,9 @@ if(mpi_rank < 1)
 			while(workingNodes > 0)	// workingNodes > 0: Slave still working -> MPI:Revc needed		workingNodes == 0: all Slaves recieved termination signal
 			{
 				// Recieve Result
-				MPI::COMM_WORLD.Recv(recieve.dataFirst(),6*N_slave*PAR.itt,MPI::DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG,status);
-				sender = status.Get_source();
-				tag = status.Get_tag();
+				MPI_Recv(recieve.dataFirst(),6*N_slave*PAR.itt,MPI_DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+				sender = status.MPI_SOURCE;
+				tag = status.MPI_TAG;
 				ofs3 << "Recieve from Node: " << sender << " Package: " << tag << endl;
 
 				// write results to file
@@ -409,12 +407,12 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,sender,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,sender,tag, MPI_COMM_WORLD);
 					ofs3 << "Send again to Node: " << sender << " Package No.: " << tag << endl;
 				}
 				else	// No Packages left -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,sender,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,sender,0, MPI_COMM_WORLD);
 					workingNodes -= 1;
 					ofs3 << "Send termination signal to Node: " << sender << endl;
 				}
@@ -544,7 +542,7 @@ if(mpi_rank > 0)
 	// each process gets a different seed
 	long idum=long(now) + 1000*mpi_rank;
 
-	MPI::COMM_WORLD.Barrier();	// Syncronize with Master
+	MPI_Barrier(MPI_COMM_WORLD);	// Syncronize with Master
 
 	ofs2 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << PAR.MapDirection << endl;
 
@@ -555,9 +553,9 @@ if(mpi_rank > 0)
 	while(1)
 	{
 		// Recieve initial conditions to calculate
-		MPI::COMM_WORLD.Recv(send_N_limits.dataFirst(),2,MPI::INTEGER,0,MPI_ANY_TAG,status);
+		MPI_Recv(send_N_limits.dataFirst(),2,MPI_INT,0,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-		tag = status.Get_tag();
+		tag = status.MPI_TAG;
 		ofs2 << endl;
 		ofs2 << "Node: " << mpi_rank << " works on Package: " << tag << endl;
 		if(tag == 0) break;	// Still work to do?  ->  tag = 0: NO, stop working
@@ -632,7 +630,7 @@ if(mpi_rank > 0)
 		} // end for n
 		
 		// Send results to Master
-		MPI::COMM_WORLD.Send(results.dataFirst(),6*N_slave*PAR.itt,MPI::DOUBLE,0,tag);
+		MPI_Send(results.dataFirst(),6*N_slave*PAR.itt,MPI_DOUBLE,0,tag, MPI_COMM_WORLD);
 
 	}// end while
 } // end Slaves
@@ -651,7 +649,7 @@ if(PAR.response_field >= 0) M3D.unload();
 #endif
 
 // MPI finalize
-MPI::Finalize();
+MPI_Finalize();
 
 return 0;
 } //end main

--- a/src/trace.cxx
+++ b/src/trace.cxx
@@ -30,11 +30,9 @@
 
 // Include
 //--------
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #include <mafot.hxx>
 #include <omp.h>
 #include <unistd.h>
@@ -54,9 +52,9 @@ using namespace blitz;
 int main(int argc, char *argv[])
 {
 // MPI initialize
-MPI::Init(argc, argv);
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+MPI_Init(&argc, &argv);
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
 // Variables
 int i,j,n,chk,ntor;
@@ -67,7 +65,7 @@ double s,u;
 int tag,sender;
 int Nmin_slave,Nmax_slave;
 Array<int,1> send_N_limits(Range(1,2));
-MPI::Status status;
+MPI_Status status;
 
 // Use system time as seed(=idum) for random numbers
 double now=zeit();
@@ -132,7 +130,7 @@ case 'h':
 		cout << "                       use option -I to specify other filename" << endl;
 		cout << endl << "Current MAFOT version is: " << MAFOT_VERSION << endl;
 	}
-	MPI::Finalize();
+	MPI_Finalize();
 	return 0;
 case 'I':
 	islandfile = optarg;
@@ -298,7 +296,7 @@ if (use_collision) COL.init(TprofileFile, NprofileFile, f, zbar, PAR.Zq, PAR.Mas
 // Prepare particles
 PARTICLE FLT(EQD,PAR,COL,mpi_rank);
 
-MPI::COMM_WORLD.Barrier();	// Syncronize all Nodes
+MPI_Barrier(MPI_COMM_WORLD);	// Syncronize all Nodes
 
 // Master only (Node 0)
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -397,7 +395,7 @@ if(mpi_rank < 1)
 		#pragma omp section	//-------- Master Thread: controlles comunication ----------------------------------------------------------------------------------------------------------------------
 		{
 			//#pragma omp barrier	// Syncronize with Slave Thread
-			MPI::COMM_WORLD.Barrier();	// Master waits for Slaves
+			MPI_Barrier(MPI_COMM_WORLD);	// Master waits for Slaves
 
 			ofs3 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << PAR.MapDirection << endl;
 			ofs3 << "Start Tracer for " << N << " points ... " << endl;
@@ -418,14 +416,14 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave_use);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,i,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,i,tag, MPI_COMM_WORLD);
 					workingNodes += 1;
 
 					ofs3 << "Send Package No.: " << tag << endl;
 				}
 				else	// more Nodes than Packages -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,i,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,i,0, MPI_COMM_WORLD);
 					ofs3 << "Send termination signal to Node: " << i << endl;
 				}
 			} // end for(i=1;i<mpi_size;i++)
@@ -434,9 +432,9 @@ if(mpi_rank < 1)
 			while(workingNodes > 0)	// workingNodes > 0: Slave still working -> MPI:Revc needed		workingNodes == 0: all Slaves recieved termination signal
 			{
 				// Recieve Result
-				MPI::COMM_WORLD.Recv(recieve.dataFirst(),N_variables*N_slave,MPI::DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG,status);
-				sender = status.Get_source();
-				tag = status.Get_tag();
+				MPI_Recv(recieve.dataFirst(),N_variables*N_slave,MPI_DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+				sender = status.MPI_SOURCE;
+				tag = status.MPI_TAG;
 				ofs3 << "Recieve from Node: " << sender << " Package: " << tag << endl;
 
 				// write results to file
@@ -468,12 +466,12 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave_use);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,sender,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,sender,tag, MPI_COMM_WORLD);
 					ofs3 << "Send again to Node: " << sender << " Package No.: " << tag << endl;
 				}
 				else	// No Packages left -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,sender,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,sender,0, MPI_COMM_WORLD);
 					workingNodes -= 1;
 					ofs3 << "Send termination signal to Node: " << sender << endl;
 				}
@@ -603,7 +601,7 @@ if(mpi_rank > 0)
 	// each process gets a different seed
 	long idum=long(now) + 1000*mpi_rank;
 
-	MPI::COMM_WORLD.Barrier();	// Syncronize with Master
+	MPI_Barrier(MPI_COMM_WORLD);	// Syncronize with Master
 
 	ofs2 << "MapDirection(0=both, 1=pos.phi, -1=neg.phi): " << PAR.MapDirection << endl;
 
@@ -614,9 +612,9 @@ if(mpi_rank > 0)
 	while(1)
 	{
 		// Recieve initial conditions to calculate
-		MPI::COMM_WORLD.Recv(send_N_limits.dataFirst(),2,MPI::INTEGER,0,MPI_ANY_TAG,status);
+		MPI_Recv(send_N_limits.dataFirst(),2,MPI_INT,0,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-		tag = status.Get_tag();
+		tag = status.MPI_TAG;
 		ofs2 << endl;
 		ofs2 << "Node: " << mpi_rank << " works on Package: " << tag << endl;
 		if(tag == 0) break;	// Still work to do?  ->  tag = 0: NO, stop working
@@ -683,7 +681,7 @@ if(mpi_rank > 0)
 		} // end for n
 		
 		// Send results to Master
-		MPI::COMM_WORLD.Send(results.dataFirst(),N_variables*N_slave,MPI::DOUBLE,0,tag);
+		MPI_Send(results.dataFirst(),N_variables*N_slave,MPI_DOUBLE,0,tag, MPI_COMM_WORLD);
 
 	}// end while
 } // end Slaves
@@ -702,7 +700,7 @@ if(PAR.response_field >= 0) M3D.unload();
 #endif
 
 // MPI finalize
-MPI::Finalize();
+MPI_Finalize();
 
 return 0;
 } //end main

--- a/src/xpand_mpi.cxx
+++ b/src/xpand_mpi.cxx
@@ -8,11 +8,9 @@
 
 // Include
 //--------
-#ifdef USE_MPICH
-	#include <mpi.h>
-#else
-	#include <openmpi/ompi/mpi/cxx/mpicxx.h>
-#endif
+#define OMPI_SKIP_MPICXX 1   // C API only: skip OpenMPI 4.x / MPICH C++ bindings (need libmpi_cxx)
+#define MPICH_SKIP_MPICXX 1
+#include <mpi.h>
 #include <omp.h>
 #include <unistd.h>
 #include <andi.hxx>
@@ -86,9 +84,9 @@ ofstream logfile;
 int main(int argc, char *argv[])
 {
 // MPI initialize
-MPI::Init(argc, argv);
-int mpi_rank = MPI::COMM_WORLD.Get_rank();
-int mpi_size = MPI::COMM_WORLD.Get_size();
+MPI_Init(&argc, &argv);
+int mpi_rank; MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+int mpi_size; MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
 
 // Variables
 int i,j, N, idx, k;
@@ -102,7 +100,7 @@ ofstream ofs3;
 int tag,sender;
 int Nmin_slave,Nmax_slave;
 Array<int,1> send_N_limits(Range(1,2));
-MPI::Status status;
+MPI_Status status;
 
 // adaptive integrator defaults
 double epsabs = 1e-6;
@@ -147,7 +145,7 @@ case 'h':
 		cout << "  mpirun -n 12 xpand_mpi -i 1500 -P ./here/my_points.dat wout.nc test" << endl;
 		cout << "  mpirun -n 12 xpand_mpi -r 1e-8 -S -M /home/shared/mgrid_d3d.nc wout.nc test2" << endl;
 	}
-	MPI::Finalize();
+	MPI_Finalize();
 	return 0;
 case 'P':
 	points_file = optarg;
@@ -245,7 +243,7 @@ int write_max = 0;
 int write_last = 0; //tag of last written data
 write_memory = 0;
 
-MPI::COMM_WORLD.Barrier();	// Syncronize all Nodes
+MPI_Barrier(MPI_COMM_WORLD);	// Syncronize all Nodes
 
 // Master only (Node 0)
 //--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -324,14 +322,14 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,i,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,i,tag, MPI_COMM_WORLD);
 					workingNodes += 1;
 
 					ofs3 << "Send Package No.: " << tag << endl;
 				}
 				else	// more Nodes than Packages -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,i,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,i,0, MPI_COMM_WORLD);
 					ofs3 << "Send termination signal to Node: " << i << endl;
 				}
 			} // end for(i=1;i<mpi_size;i++)
@@ -340,9 +338,9 @@ if(mpi_rank < 1)
 			while(workingNodes > 0)	// workingNodes > 0: Slave still working -> MPI:Revc needed		workingNodes == 0: all Slaves recieved termination signal
 			{
 				// Recieve Result
-				MPI::COMM_WORLD.Recv(recieve.dataFirst(),N_transmit*N_slave,MPI::DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG,status);
-				sender = status.Get_source();
-				tag = status.Get_tag();
+				MPI_Recv(recieve.dataFirst(),N_transmit*N_slave,MPI_DOUBLE,MPI_ANY_SOURCE,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
+				sender = status.MPI_SOURCE;
+				tag = status.MPI_TAG;
 				ofs3 << "Recieve from Node: " << sender << " Package: " << tag << endl;
 
 				#pragma omp critical
@@ -370,12 +368,12 @@ if(mpi_rank < 1)
 					send_N_limits(1) = N_values((tag-1)*N_slave+1);	// Nmin_slave
 					send_N_limits(2) = N_values(tag*N_slave);	// Nmax_slave
 
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),2,MPI::INTEGER,sender,tag);
+					MPI_Send(send_N_limits.dataFirst(),2,MPI_INT,sender,tag, MPI_COMM_WORLD);
 					ofs3 << "Send again to Node: " << sender << " Package No.: " << tag << endl;
 				}
 				else	// No Packages left -> Send termination signal: tag = 0
 				{
-					MPI::COMM_WORLD.Send(send_N_limits.dataFirst(),0,MPI::INTEGER,sender,0);
+					MPI_Send(send_N_limits.dataFirst(),0,MPI_INT,sender,0, MPI_COMM_WORLD);
 					workingNodes -= 1;
 					ofs3 << "Send termination signal to Node: " << sender << endl;
 				}
@@ -556,9 +554,9 @@ if(mpi_rank > 0)
 	while(1)
 	{
 		// Recieve initial conditions to calculate
-		MPI::COMM_WORLD.Recv(send_N_limits.dataFirst(),2,MPI::INTEGER,0,MPI_ANY_TAG,status);
+		MPI_Recv(send_N_limits.dataFirst(),2,MPI_INT,0,MPI_ANY_TAG, MPI_COMM_WORLD, &status);
 
-		tag = status.Get_tag();
+		tag = status.MPI_TAG;
 		if(tag == 0) break;	// Still work to do?  ->  tag = 0: NO, stop working
 
 		Nmin_slave = send_N_limits(1);
@@ -620,7 +618,7 @@ if(mpi_rank > 0)
 		} // end for
 
 		// Send results to Master
-		MPI::COMM_WORLD.Send(results.dataFirst(),N_transmit*N_slave,MPI::DOUBLE,0,tag);
+		MPI_Send(results.dataFirst(),N_transmit*N_slave,MPI_DOUBLE,0,tag, MPI_COMM_WORLD);
 
 	}// end while
 } // end Slaves
@@ -634,7 +632,7 @@ if(mpi_rank < 1)
 }
 
 // MPI finalize
-MPI::Finalize();
+MPI_Finalize();
 
 return 0;
 }  //end of main


### PR DESCRIPTION
## Summary

OpenMPI 5.0 removed the deprecated MPI C++ bindings (`mpicxx.h` headers and
`libmpi_cxx`), which breaks the build of all `_mpi` tools on current distros
(e.g. Ubuntu 24.04+). This PR ports MAFOT's MPI usage to the portable C API,
which exists in every MPI implementation and version:

- Replace the C++ bindings (`MPI::COMM_WORLD.*`, `MPI::Status`, `MPI::DOUBLE`,
  `Get_source()`/`Get_tag()`, ...) with the C API across `laminar_mpi`,
  `foot_mpi`, `plot_mpi`, `trace`, `xpand_mpi`, and the xpand/vmec/andi headers.
- Define `OMPI_SKIP_MPICXX` / `MPICH_SKIP_MPICXX` before `#include <mpi.h>` so
  no C++ bindings are pulled in on OpenMPI 4.x (whose `mpi.h` auto-includes
  them and would otherwise require `-lmpi_cxx` at link).
- Drop `-lmpi_cxx` from all `install/make.inc.*` templates (gone in OpenMPI
  5.0; unnecessary on 4.x now that only the C API is used).

No functional change to the tracing algorithms; MPI semantics are preserved
1:1 (same tags, same master/slave dispatch).

## Testing

- Builds and links against OpenMPI 4.1.6 (Ubuntu 24.04) with only `-lmpi`.
- `laminar_mpi` (4 ranks, 900-point R-Z grid, 150 turns, MapDirection=0) runs
  the full master/slave dispatch cleanly.
- Poincaré regression: `dtplot` on the DIII-D 126006/3600 test case
  (`tests/_plot.dat`, I-coil on) reproduces the pre-port reference output —
  first 200 rows agree to ~1e-8 relative; column statistics to ~0.3 %
  (remaining spread is chaotic field-line divergence, not a code difference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
